### PR TITLE
Refactor node labeling into role

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -44,27 +44,6 @@
 - name: Node labeling/tainting
   hosts: pi4-worker
   gather_facts: false
-  tasks:
-    - name: Set node labels
-      ansible.builtin.shell: |
-        kubectl label node {{ k8s_node_name }} role={{ node_role }} power={{ power_policy }} --kubeconfig {{ playbook_dir }}/files/k3s.yaml --overwrite
-      when: node_role is defined and power_policy is defined and k8s_node_name is defined
-      delegate_to: localhost
-      changed_when: true
-      register: label_result
+  roles:
+    - k3s_node_labeling
 
-    - name: Show label command result
-      debug:
-        var: label_result
-
-    - name: Set node taints
-      ansible.builtin.shell: |
-        kubectl taint node {{ k8s_node_name }} {{ node_taint }} --kubeconfig {{ playbook_dir }}/files/k3s.yaml --overwrite
-      when: node_taint is defined and k8s_node_name is defined
-      delegate_to: localhost
-      changed_when: true
-      register: taint_result
-
-    - name: Show taint command result
-      debug:
-        var: taint_result


### PR DESCRIPTION
## Summary
- switch `Node labeling/tainting` block to use the existing `k3s_node_labeling` role
- keep node labeling variables in `group_vars/pi4-worker.yml`

## Testing
- `ansible-playbook ansible/playbook.yml --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f497f9fc8320944f4db327dcd4f0